### PR TITLE
Fix pkgbuild script

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -83,7 +83,7 @@ build() {
         -DCATKIN_BUILD_BINARY_PACKAGE=ON \
         -DCMAKE_INSTALL_PREFIX=/opt/ros/noetic \
         -DPYTHON_EXECUTABLE=/usr/bin/python \
-        -DSETUPTOOLS_DEB_LAYOUT=OFF \
+        -DSETUPTOOLS_DEB_LAYOUT=OFF
   make
 }
 


### PR DESCRIPTION
The slash on line 86 was causing the make command to be interpret as a directory for the cmake command, and thus causing a build failure.